### PR TITLE
[PAK-5563] Move palcrypt.conf to separate sub-directory

### DIFF
--- a/roles/install-production-server/tasks/files-and-scripts/create-directory-structure.yml
+++ b/roles/install-production-server/tasks/files-and-scripts/create-directory-structure.yml
@@ -46,6 +46,7 @@
     - /smartmet/cnf/cron/cron.daily 
     - /smartmet/cnf/cron/cron.weekly
     - /smartmet/cnf/cron/cron.monthly
+    - /smartmet/cnf/palcrypt
     - /smartmet/cnf/triggers.d/quick
     - /smartmet/cnf/triggers.d/lazy
     - /smartmet/editor/in

--- a/roles/install-production-server/tasks/files-and-scripts/required-files-and-scripts.yml
+++ b/roles/install-production-server/tasks/files-and-scripts/required-files-and-scripts.yml
@@ -55,10 +55,10 @@
     src: "cnf/smartmet.conf"
     dest:  /smartmet/cnf/smartmet.conf
 
-- name: Add /smartmet/cnf/palcrypt.conf
+- name: Add /smartmet/cnf/palcrypt/palcrypt.conf
   copy:
     src: "cnf/palcrypt.conf"
-    dest:  /smartmet/cnf/palcrypt.conf
+    dest:  /smartmet/cnf/palcrypt/palcrypt.conf
 
 - name: Add /smartmet/cnf/misc/arrow.path
   copy:


### PR DESCRIPTION
Related to [FMI issue PAK-5563](https://jira.fmi.fi/browse/PAK-5563) and possibly related to https://github.com/fmidev/smartmet-base-international/pull/1.

Install `palcrypt.conf` under `/smartmet/cnf/palcrypt/` instead of the root `/smartmet/cnf`.

This allows finer‑grained volume mounts in container setups, so only the required sub‑directory is exposed.

If this change is not relevant for external/foreign installs, please close the PR without merging.